### PR TITLE
split race test and coverage generation

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Optional init
       run: make dependencies || true # Used in fortio for instance to prep for go tests
     - name: Run test coverage
-      run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+      run: go test -coverprofile=coverage.out ./...
     - uses: codecov/codecov-action@v3
       with:
         files: coverage.out

--- a/.github/workflows/gochecks.yml
+++ b/.github/workflows/gochecks.yml
@@ -27,3 +27,7 @@ jobs:
         run: curl -fsS -o .golangci.yml https://raw.githubusercontent.com/fortio/workflows/main/golangci.yml
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # pin@v3
+      - name: Optional init
+        run: make dependencies || true # Used in fortio for instance to prep for go tests
+      - name: Run tests with race detector
+        run: go test -race ./...


### PR DESCRIPTION
somehow using -race reduces coverage/prevents log debug path to be exercised in fortio tests (!)