### PR TITLE
Clean golangci-lint configuration

### DIFF
--- a/.github/workflows/gochecks.yml
+++ b/.github/workflows/gochecks.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Download linter config
         run: curl -fsS -o .golangci.yml https://raw.githubusercontent.com/fortio/workflows/main/golangci.yml
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # pin@v3
+        uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # pin@v6
       - name: Optional init
         run: make dependencies || true # Used in fortio for instance to prep for go tests
       - name: Run tests with race detector

--- a/golangci.yml
+++ b/golangci.yml
@@ -28,8 +28,6 @@ linters-settings:
     # check all top-level comments, not only declarations
     check-all: false
   govet:
-    # report about shadowed variables
-    shadow: true
     # settings per analyzer
     settings:
       printf: # analyzer name, run `go tool vet help` to see all analyzers
@@ -74,14 +72,6 @@ linters:
     # bad ones:
     - musttag
     # Deprecated ones:
-    - scopelint
-    - golint
-    - interfacer
-    - maligned
-    - varcheck
-    - structcheck
-    - nosnakecase
-    - deadcode
     - gomnd
     # Weird/bad ones:
     - wsl


### PR DESCRIPTION
- govet: the option `shadow` doesn't exist
- disable: the deprecated linters (level 2 of the deprecation) are removed from the `enable-all` https://github.com/golangci/golangci-lint/pull/4681

tips: 

```bash
golangci-lint config verify --config golangci.yml
```