### PR TITLE
go 1.22.5 is out: changing go-versions manually

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # pin@v5
         with:
-          go-version: '1.22'
+          go-version: '1.22.5'
           check-latest: true
       - name: Run test coverage
         run: |

--- a/.github/workflows/gochecks.yml
+++ b/.github/workflows/gochecks.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # pin@v5
         with:
-          go-version: '1.22'
+          go-version: '1.22.5'
           check-latest: true
       - name: Run Vulncheck
         run: |

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # pin@v5
         with:
-          go-version: '1.22'
+          go-version: '1.22.5'
           check-latest: true
       - name: Download goreleaser config
         run: curl -fsS -o .goreleaser.yaml https://raw.githubusercontent.com/fortio/workflows/main/goreleaser.yaml # same use branch for testing instead of main in #38


### PR DESCRIPTION
annoying neither docker hub nor setup-go have it, 3h later

so `1.22` + `latest:true` doesn't work

ref: https://github.com/actions/setup-go/issues/407
ref: https://github.com/docker-library/official-images/pull/17104
ref: https://github.com/fortio/fortio/pull/950