### PR TITLE
adapt settings to golangci-lint  1.59.1

### DIFF
--- a/golangci.yml
+++ b/golangci.yml
@@ -58,6 +58,7 @@ linters-settings:
     max-func-lines: 30
   nolintlint:
     require-specific: true
+    # require-explanation: true # add this when we fix it/review nolints in fortio/fortio
   whitespace:
     multi-if: false   # Enforces newlines (or comments) after every multi-line if statement
     multi-func: false # Enforces newlines (or comments) after every multi-line function signature
@@ -74,6 +75,8 @@ linters:
     # Deprecated ones:
     - gomnd
     - execinquery
+    # Redundant ones:
+    - gofmt # we use gofumpt
     # Weird/bad ones:
     - wsl
     - nlreturn

--- a/golangci.yml
+++ b/golangci.yml
@@ -73,6 +73,7 @@ linters:
     - musttag
     # Deprecated ones:
     - gomnd
+    - execinquery
     # Weird/bad ones:
     - wsl
     - nlreturn
@@ -81,7 +82,6 @@ linters:
     - mnd
     - testpackage
     - wrapcheck
-    - exhaustivestruct
     - tagliatelle
     - nonamedreturns
     - varnamelen
@@ -90,7 +90,6 @@ linters:
     - paralleltest
     - thelper
     - forbidigo
-    - ifshort
     - wastedassign
     - cyclop
     - forcetypeassert


### PR DESCRIPTION
removes:
```
level=warning msg="[lintersdb] The linter \"exhaustivestruct\" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle"
level=warning msg="[lintersdb] The linter \"ifshort\" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle"
level=warning msg="The linter 'execinquery' is deprecated (since v1.58.0) due to: The repository of the linter has been archived by the owner. "
```