### PR TITLE
Pin golangci-lint version

### DIFF
--- a/.github/workflows/gochecks.yml
+++ b/.github/workflows/gochecks.yml
@@ -27,6 +27,8 @@ jobs:
         run: curl -fsS -o .golangci.yml https://raw.githubusercontent.com/fortio/workflows/main/golangci.yml
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # pin@v6
+        with:
+          version: v1.60.3        
       - name: Run tests
         run: |
           go version

--- a/golangci.yml
+++ b/golangci.yml
@@ -77,6 +77,7 @@ linters:
     # Deprecated ones:
     - gomnd
     - execinquery
+    - exportloopref
     # Redundant ones:
     - gofmt # we use gofumpt
     # Weird/bad ones:


### PR DESCRIPTION
Pending https://github.com/golangci/golangci-lint-action/issues/1091

Will avoid future breakages without code change or go version changes like we had with gosec int conversions
