### PR TITLE
Switch to go 1.24(.6) and golangci-lint v2.3.1 (new config)

### DIFF
--- a/.github/workflows/gochecks.yml
+++ b/.github/workflows/gochecks.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # pin@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           check-latest: true
       - name: Run Vulncheck
         if: matrix.os == 'ubuntu-latest'
@@ -32,16 +32,9 @@ jobs:
         run: curl -fsS -o .golangci.yml https://raw.githubusercontent.com/fortio/workflows/main/golangci.yml
       - name: Run golangci-lint
         if: matrix.os == 'ubuntu-latest'
-        uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # pin@v6
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # pin@v8
         with:
-          version: v1.62.2
-# Both make and bash are present in current windows-latest
-#      - name: Install Git Bash
-#        run: |
-#          choco install git
-#          echo "Git Bash installed"
-#        shell: pwsh
-#        if: runner.os == 'Windows'
+          version: v2.3.1
       - name: Run tests
         run: |
           go version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/fortio/workflows
 
-go 1.21
+// Just to test linters, we don't actually require anything recent here.
+go 1.24
 
 // toolchain go1.22.3 // this shouldn't be necessary - see https://github.com/golang/go/issues/66175#issuecomment-2010343876
 

--- a/golangci.yml
+++ b/golangci.yml
@@ -1,96 +1,24 @@
 # Config for golangci-lint - shared across fortio org projects (included by gochecks workflow step)
+# Migrated to v2.
 
-# output configuration options
-
-# all available settings of specific linters
-linters-settings:
-  dupl:
-    # tokens count to trigger issue, 150 by default
-    threshold: 100
-  exhaustive:
-    # indicates that switch statements are to be considered exhaustive if a
-    # 'default' case is present, even if all enum members aren't listed in the
-    # switch
-    default-signifies-exhaustive: true
-  funlen:
-    lines: 140
-    statements: 70
-  gocognit:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 42
-  nestif:
-    # minimal complexity of if statements to report, 5 by default
-    min-complexity: 4
-  gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 30
-  godot:
-    # check all top-level comments, not only declarations
-    check-all: false
-  govet:
-    # settings per analyzer
-    settings:
-      printf: # analyzer name, run `go tool vet help` to see all analyzers
-        funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Printf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).FErrf
-    enable-all: true
-    disable-all: false
-  lll:
-    # max line length, lines longer will be reported. Default is 120.
-    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
-    line-length: 132
-    # tab width in spaces. Default to 1.
-    tab-width: 1
-  misspell:
-    # Correct spellings using locale preferences for US or UK.
-    # Default is to use a neutral variety of English.
-    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
-    locale: US
-    ignore-words:
-      - fortio
-  nakedret:
-    # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
-    max-func-lines: 30
-  nolintlint:
-    require-specific: true
-    # require-explanation: true # add this when we fix it/review nolints in fortio/fortio
-  whitespace:
-    multi-if: false   # Enforces newlines (or comments) after every multi-line if statement
-    multi-func: false # Enforces newlines (or comments) after every multi-line function signature
-  gofumpt:
-    # Choose whether or not to use the extra rules that are disabled
-    # by default
-    extra-rules: false
-
-
+version: "2"
 linters:
+  default: all
   disable:
+    - exhaustruct # seems like a good idea at first but actually a pain and go does have zero values for a reason.
+    - gochecknoglobals
+    - gochecknoinits
     # can't get it to accept //nolint so... have to disable it
     - gomoddirectives
-    # bad ones:
-    - musttag
-    # Deprecated ones:
-    - exportloopref
-    # Redundant ones:
-    - gofmt # we use gofumpt
-    # Weird/bad ones:
     - mnd
-    - wsl
+    - musttag
     - nlreturn
-    - gochecknoinits
-    - gochecknoglobals
-    - testpackage
-    - wrapcheck
-    - tagliatelle
     - nonamedreturns
+    - tagliatelle
+    - testpackage
     - varnamelen
-    - exhaustruct # seems like a good idea at first but actually a pain and go does have zero values for a reason.
-# TODO consider putting these back, when they stop being bugged (ifshort, wastedassign,...)
+    - wrapcheck
+    # consider putting these back, when they stop being bugged (ifshort, wastedassign,...)
     - paralleltest
     - thelper
     - forbidigo
@@ -99,64 +27,120 @@ linters:
     - forcetypeassert
     - ireturn
     - depguard
-  enable-all: true
-  disable-all: false
-  # Must not use fast: true in newer golangci-lint or it'll just skip a bunch of linter instead of doing caching like before (!)
-  fast: false
-
-
+    # newer bad ones:
+    - wsl
+    - wsl_v5
+    - funcorder
+    - noinlineerr # prize for worst linter ever
+    - embeddedstructfieldcheck
+    - gosmopolitan
+  settings:
+    staticcheck:
+      # dot-import-whitelist: [] # Note: not yet working
+      dot-import-whitelist:
+        - github.com/does/not/exist # until we can put [] in the config
+      # http-status-code-whitelist: [] # Note: not yet working
+      http-status-code-whitelist:
+        - "418" # until we can put [] in the config/allow teapot!
+      checks:
+        - all
+        - -QF1008
+    dupl:
+      threshold: 100
+    exhaustive:
+      default-signifies-exhaustive: true
+    funlen:
+      lines: 140
+      statements: 70
+    gocognit:
+      min-complexity: 42
+    gocyclo:
+      min-complexity: 30
+    govet:
+      enable-all: true
+      disable-all: false
+      settings:
+        printf:
+          funcs:
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Printf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).FErrf
+    lll:
+      line-length: 132
+      tab-width: 1
+    misspell:
+      locale: US
+      ignore-rules:
+        - fortio
+    nakedret:
+      max-func-lines: 30
+    nestif:
+      min-complexity: 4
+    nolintlint:
+      require-specific: true
+      require-explanation: true
+    whitespace:
+      multi-if: false
+      multi-func: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - err113
+          - errcheck
+          - forcetypeassert
+          - gochecknoglobals
+          - gochecknoinits
+          - goconst
+          - gocyclo
+          - gosec
+          - noctx
+          - nosnakecase
+        path: _test\.go
+      - linters:
+          - lll
+        source: '^//go:generate '
+      - linters:
+          - err113
+        text: do not define dynamic errors
+      - linters:
+          - govet
+        text: 'fieldalignment:'
+      - linters:
+          - godox
+        text: TODO
+      - linters:
+          - nosnakecase
+        text: grpc_|_SERVING|O_
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test\.go
-      linters:
-        - gocyclo
-        - errcheck
-        - dupl
-        - gosec
-        - gochecknoinits
-        - gochecknoglobals
-        - forcetypeassert
-        - nosnakecase
-        - noctx
-        - goconst
-        - err113
-
-    # Exclude lll issues for long lines with go:generate
-    - linters:
-        - lll
-      source: "^//go:generate "
-    - linters:
-        - err113
-      text: "do not define dynamic errors"
-    - linters:
-        - govet
-      text: "fieldalignment:"
-    - linters:
-        - godox
-      text: "TODO"
-    - linters:
-        - nosnakecase
-      text: "grpc_|_SERVING|O_"
-
-  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0
-
-  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0
-
 severity:
-  # Default value is empty string.
-  # Set the default severity for issues. If severity rules are defined and the issues
-  # do not match or no severity is provided to the rule this will be the default
-  # severity applied. Severities should match the supported severity names of the
-  # selected out format.
-  # - Code climate: https://docs.codeclimate.com/docs/issues#issue-severity
-  # -   Checkstyle: https://checkstyle.sourceforge.io/property_types.html#severity
-  # -       Github: https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
-  default-severity: error
-
-  # The default value is false.
-  # If set to true severity-rules regular expressions become case sensitive.
-  case-sensitive: false
+  default: error
+formatters:
+  enable:
+    - gci
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: false
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
It does generate a number of new issues in fortio/fortio and a few in terminal, grol etc... but worth fixing